### PR TITLE
Bicep DLL v0.4.1008 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,5 @@ project.lock.json
 #####
 # End of core ignore list, below put you custom 'per project' settings (patterns or path)
 #####
+
+BicepNet.PS.zip

--- a/BicepNet.Core/BicepNet.Core.csproj
+++ b/BicepNet.Core/BicepNet.Core.csproj
@@ -6,8 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\TMP\bicep\src\Bicep.Core\Bicep.Core.csproj" />
-    <ProjectReference Include="..\TMP\bicep\src\Bicep.Decompiler\Bicep.Decompiler.csproj" />
+    <ProjectReference Include="..\..\bicep\src\Bicep.Core\Bicep.Core.csproj" />
+    <ProjectReference Include="..\..\bicep\src\Bicep.Decompiler\Bicep.Decompiler.csproj" />
+    <Content Include="bicepconfig.json">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/BicepNet.Core/BicepWrapper.Build.cs
+++ b/BicepNet.Core/BicepWrapper.Build.cs
@@ -1,12 +1,18 @@
+using Bicep.Core.Configuration;
 using Bicep.Core.Emit;
+using Bicep.Core.Features;
 using Bicep.Core.FileSystem;
+using Bicep.Core.Json;
 using Bicep.Core.Registry;
+using Bicep.Core.Registry.Auth;
 using Bicep.Core.Semantics;
+using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.Workspaces;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions;
 
 namespace BicepNet.Core
 {
@@ -20,17 +26,30 @@ namespace BicepNet.Core
                 Formatting = Formatting.Indented
             };
 
+            var fileSystem = new FileSystem();
+
+            var configuration = RootConfiguration.Bind(
+                JsonElementFactory.CreateElement(
+                    fileSystem.FileStream.Create(BuiltInConfigurationResourcePath, FileMode.Open, FileAccess.Read))
+                );
+
             var inputUri = PathHelper.FilePathToFileUrl(bicepPath);
             var fileResolver = new FileResolver();
-            var dispatcher = new ModuleDispatcher(new DefaultModuleRegistryProvider(fileResolver));
-            var sourceFileGrouping = SourceFileGroupingBuilder.Build(fileResolver, dispatcher, new Workspace(), inputUri);
-            var compilation = new Compilation(AzResourceTypeProvider.CreateWithAzTypes(), sourceFileGrouping);
+            var tokenCredentialFactory = new TokenCredentialFactory();
+            var featureProvider = new FeatureProvider();
+            var moduleRegistryProvider = new DefaultModuleRegistryProvider(fileResolver,
+                new ContainerRegistryClientFactory(tokenCredentialFactory),
+                new TemplateSpecRepositoryFactory(tokenCredentialFactory),
+                featureProvider);
+            var dispatcher = new ModuleDispatcher(moduleRegistryProvider);
+            var sourceFileGrouping = SourceFileGroupingBuilder.Build(fileResolver, dispatcher, new Workspace(), inputUri, configuration);
+            var compilation = new Compilation(new DefaultNamespaceProvider(new AzResourceTypeLoader(), featureProvider), sourceFileGrouping, configuration);
             var template = new List<string>();
 
             var (success, dignosticResult) = LogDiagnostics(compilation);
             if (success)
             {
-                var emitter = new TemplateEmitter(compilation.GetEntrypointSemanticModel(), BicepVersion);
+                var emitter = new TemplateEmitter(compilation.GetEntrypointSemanticModel(), new EmitterSettings(featureProvider));
                 emitter.Emit(writer);
                 template.Add(sw.ToString());
             }
@@ -39,7 +58,6 @@ namespace BicepNet.Core
                 template,
                 dignosticResult
             );
-
         }
 
         private static (bool success, ICollection<DiagnosticEntry> dignosticResult) LogDiagnostics(Compilation compilation)

--- a/BicepNet.Core/BicepWrapper.Decompile.cs
+++ b/BicepNet.Core/BicepWrapper.Decompile.cs
@@ -1,8 +1,16 @@
+using Bicep.Core.Configuration;
+using Bicep.Core.Features;
 using Bicep.Core.FileSystem;
+using Bicep.Core.Json;
+using Bicep.Core.Registry;
+using Bicep.Core.Registry.Auth;
+using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.TypeSystem.Az;
 using Bicep.Decompiler;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
 
 namespace BicepNet.Core
 {
@@ -13,18 +21,33 @@ namespace BicepNet.Core
             return Decompile(templatePath, null, null);
         }
 
-        public static IDictionary<string,string> Decompile(string templatePath, string? outputDir, string? outputFile)
+        public static IDictionary<string, string> Decompile(string templatePath, string? outputDir, string? outputFile)
         {
             var inputPath = PathHelper.ResolvePath(templatePath);
 
             static string DefaultOutputPath(string path) => PathHelper.GetDefaultDecompileOutputPath(path);
             var outputPath = PathHelper.ResolveDefaultOutputPath(inputPath, outputDir, outputFile, DefaultOutputPath);
-            
+
             Uri inputUri = PathHelper.FilePathToFileUrl(inputPath);
             Uri outputUri = PathHelper.FilePathToFileUrl(outputPath);
 
+            var fileSystem = new FileSystem();
+
+            var configuration = RootConfiguration.Bind(
+                JsonElementFactory.CreateElement(
+                    fileSystem.FileStream.Create(BuiltInConfigurationResourcePath, FileMode.Open, FileAccess.Read))
+                );
+            var featureProvider = new FeatureProvider();
+            var fileResolver = new FileResolver();
+            var tokenCredentialFactory = new TokenCredentialFactory();
+            var moduleRegistryProvider = new DefaultModuleRegistryProvider(fileResolver,
+                new ContainerRegistryClientFactory(tokenCredentialFactory),
+                new TemplateSpecRepositoryFactory(tokenCredentialFactory),
+                featureProvider);
+
             var template = new Dictionary<string,string>();
-            var decompilation = TemplateDecompiler.DecompileFileWithModules(AzResourceTypeProvider.CreateWithAzTypes(), new FileResolver(), inputUri, outputUri);
+            var templateDecompiler = new TemplateDecompiler(new DefaultNamespaceProvider(new AzResourceTypeLoader(), featureProvider), fileResolver, moduleRegistryProvider, new ConfigurationManager(fileSystem));
+            var decompilation = templateDecompiler.DecompileFileWithModules(inputUri, outputUri);
             
             foreach (var (fileUri, bicepOutput) in decompilation.filesToSave)
             {

--- a/BicepNet.Core/BicepWrapper.cs
+++ b/BicepNet.Core/BicepWrapper.cs
@@ -1,11 +1,14 @@
 using Bicep.Core.Workspaces;
+using System.IO;
 using System.Diagnostics;
+using System.Reflection;
 
 namespace BicepNet.Core
 {
     public partial class BicepWrapper
     {
-        public static string BicepVersion { get; } = FileVersionInfo.GetVersionInfo(typeof(Workspace).Assembly.Location).FileVersion;
+        public static string BuiltInConfigurationResourcePath = $"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}\\bicepconfig.json";
 
+        public static string BicepVersion { get; } = FileVersionInfo.GetVersionInfo(typeof(Workspace).Assembly.Location).FileVersion;
     }
 }

--- a/BicepNet.Core/bicepconfig.json
+++ b/BicepNet.Core/bicepconfig.json
@@ -1,0 +1,59 @@
+{
+  "cloud": {
+    "currentProfile": "AzureCloud",
+    "profiles": {
+      "AzureCloud": {
+        "resourceManagerEndpoint": "https://management.azure.com",
+        "activeDirectoryAuthority": "https://login.microsoftonline.com"
+      },
+      "AzureChinaCloud": {
+        "resourceManagerEndpoint": "https://management.chinacloudapi.cn",
+        "activeDirectoryAuthority": "https://login.chinacloudapi.cn"
+      },
+      "AzureUSGovernment": {
+        "resourceManagerEndpoint": "https://management.usgovcloudapi.net",
+        "activeDirectoryAuthority": "https://login.microsoftonline.us"
+      }
+    },
+    "credentialPrecedence": [
+      "AzureCLI",
+      "AzurePowerShell"
+    ]
+  },
+  "moduleAliases": {
+    "ts": {},
+    "br": {}
+  },
+  "analyzers": {
+    "core": {
+      "verbose": false,
+      "enabled": true,
+      "rules": {
+        "no-hardcoded-env-urls": {
+          "level": "warning",
+          "disallowedhosts": [
+            "gallery.azure.com",
+            "management.core.windows.net",
+            "management.azure.com",
+            "database.windows.net",
+            "core.windows.net",
+            "login.microsoftonline.com",
+            "graph.windows.net",
+            "trafficmanager.net",
+            "datalake.azure.net",
+            "azuredatalakestore.net",
+            "azuredatalakeanalytics.net",
+            "vault.azure.net",
+            "api.loganalytics.io",
+            "asazure.windows.net",
+            "region.asazure.windows.net",
+            "batch.core.windows.net"
+          ],
+          "excludedhosts": [
+            "schema.management.azure.com"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -59,6 +59,7 @@ ForEach-Object {
     Copy-Item -LiteralPath $_.FullName -Destination $corePath
 }
 
+Copy-Item -Path "$ProjectRoot/BicepNet.Core/bin/$Configuration/netstandard2.1/bicepconfig.json" -Destination $commonPath
 Copy-Item -Path "$ProjectRoot/BicepNet.PS/Manifest/BicepNet.PS.psd1" -Destination $outPath
 if (-not $PSBoundParameters.ContainsKey('Version')) {
     try {


### PR DESCRIPTION
Also changed the path of the Bicep source to "..\..\bicep\" instead of "..\TMP\bicep\". This allows you to clone both repositories into the same directory and then just build BicepNet.