### PR TITLE
Add errorhandling for http 401 and invalid acr url

### DIFF
--- a/BicepNet.Core/BicepWrapper.FindModule.cs
+++ b/BicepNet.Core/BicepWrapper.FindModule.cs
@@ -124,6 +124,29 @@ namespace BicepNet.Core
                         repos.Add(bicepRepository);
                     }
                 }
+                catch (Azure.RequestFailedException ex)
+                {
+                    switch (ex.Status)
+                    {
+                        case 401:
+                            logger.LogWarning($"The credentials provided are not authorized to the following registry: {endpoint}");
+                            break;
+                        default:
+                            logger.LogError(ex, $"Could not get modules from endpoint {endpoint}!");
+                            break;
+                    }
+                }
+                catch (System.AggregateException ex)
+                {
+                    if (ex.InnerException != null)
+                    {
+                        logger.LogWarning(ex.InnerException.Message);
+                    }
+                    else
+                    {
+                        logger.LogError(ex, $"Could not get modules from endpoint {endpoint}!");
+                    }
+                }
                 catch (Exception ex)
                 {
                     logger.LogError(ex, $"Could not get modules from endpoint {endpoint}!");


### PR DESCRIPTION
Added some error handling. Access denired and invalid acr url will now result in a more friendly warning message.

Fixes #21 