### PR TITLE
`Find-BicepNetModule` has more module metadata and sorts tags by UpdatedOn

### DIFF
--- a/BicepNet.Core/Models/BicepRepositoryModuleTag.cs
+++ b/BicepNet.Core/Models/BicepRepositoryModuleTag.cs
@@ -1,20 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace BicepNet.Core.Models
 {
-    public class BicepRepositoryModule
+    public class BicepRepositoryModuleTag
     {
+        public string Name { get; set; }
         public string Digest { get; set; }
-        public string Repository { get; set; }
-        public IList<BicepRepositoryModuleTag> Tags { get; set; }
+        public string Target { get; set; }
+
         public DateTimeOffset CreatedOn { get; set; }
         public DateTimeOffset UpdatedOn { get; set; }
 
         public override string ToString()
         {
-            return string.Join(", ", Tags.OrderByDescending(t => t.UpdatedOn).Select(t => t.ToString()));
+            return Name;
         }
     }
 }


### PR DESCRIPTION
The command `Find-BicepNetModule` now has more metadata for `CreatedOn` and `UpdatedOn` and the `Tags` property is no longer just a list of strings but has its own object type with more properties.

Solves:
- #24
- #22

![image](https://user-images.githubusercontent.com/3384251/161303778-2a5a00b0-594f-48b9-bd30-38c06efe802f.png)
