### PR TITLE
verify installed .net version in dependency verification script

### DIFF
--- a/scripts/Dependencies.ps1
+++ b/scripts/Dependencies.ps1
@@ -2,6 +2,16 @@ param(
     $bicepVersion
 )
 
+try {
+    [version]$DotNetVersion = dotnet --version
+    if ($DotNetVersion.Major -lt 6) {
+        throw
+    }
+}
+catch {
+    throw '.net 6 is required to build BicepNet. Get it at https://dotnet.microsoft.com/en-us/download/dotnet/6.0'
+}
+
 if(-not $bicepVersion) {
     $bicepVersion = Get-Content -Path "$PSScriptRoot\..\.bicepVersion"
     $bicepVersion = $bicepVersion.Trim()


### PR DESCRIPTION
closes #26 

This pr adds a verification to the dependencies.ps1 script to verify .Net 6 is installed.