### PR TITLE
Use Nuget package for Decompiler

### DIFF
--- a/BicepNet.Core/BicepNet.Core.csproj
+++ b/BicepNet.Core/BicepNet.Core.csproj
@@ -15,12 +15,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" PrivateAssets="All" />
+    <PackageReference Include="Azure.Bicep.Decompiler" Version="0.10.61" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.3.44" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\TMP\bicep\src\Bicep.LangServer\Bicep.LangServer.csproj" />
-    <ProjectReference Include="..\TMP\bicep\src\Bicep.Decompiler\Bicep.Decompiler.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Even if LanguageServer is not published to Nuget, we can use the published Decompiler from Nuget. It shaves of a few seconds on the build and we might get published under "Used By"