### PR TITLE
Added workflow to fool dependency graph

### DIFF
--- a/.github/workflows/dependabot_hack.yml
+++ b/.github/workflows/dependabot_hack.yml
@@ -1,0 +1,15 @@
+---
+name: Dependabot hack
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - never-trigger-this-dependabot-hack-workflow
+
+jobs:
+
+  dependabot_hack:
+    name: Ensure dependabot version checks
+    runs-on: ubuntu-20.04
+    steps:    
+      # Dockerfile:
+      - uses: azure/bicep@v0.10.61


### PR DESCRIPTION
Not sure if this will work or not. 😊

Noticed that we didn't get listed under `used-by` under the Azure/Bicep repo after changing to the decompiler nuget package. Had a look at the two listed and borrowed a workflow that I believe might do the trick. Inspiration: https://github.com/miqm/bicep-cli/blob/main/.github/workflows/dependabot_hack.yml
