### PR TITLE
Add support for building bicepparam files

### DIFF
--- a/BicepNet.Core/BicepWrapper.Build.cs
+++ b/BicepNet.Core/BicepWrapper.Build.cs
@@ -67,7 +67,7 @@ public partial class BicepWrapper
         {
             var bicepFileUsingPathUri = bicepSemanticModel.Root.FileUri;
 
-            if (bicepPath is { } && !bicepFileUsingPathUri.Equals(PathHelper.FilePathToFileUrl(bicepPath)))
+            if (bicepPath is not null && !bicepFileUsingPathUri.Equals(PathHelper.FilePathToFileUrl(bicepPath)))
             {
                 throw new InvalidOperationException($"Bicep file {bicepPath} provided with templatePath option doesn't match the Bicep file {bicepSemanticModel.Root.Name} referenced by the using declaration in the parameters file");
             }

--- a/BicepNet.Core/BicepWrapper.Build.cs
+++ b/BicepNet.Core/BicepWrapper.Build.cs
@@ -1,5 +1,6 @@
 using Bicep.Core.Emit;
 using Bicep.Core.FileSystem;
+using Bicep.Core.Semantics;
 using Bicep.Core.Workspaces;
 using Microsoft.Extensions.Logging;
 using System;
@@ -11,9 +12,9 @@ namespace BicepNet.Core;
 
 public partial class BicepWrapper
 {
-    public IList<string> Build(string bicepPath, bool noRestore = false) => joinableTaskFactory.Run(() => BuildAsync(bicepPath, noRestore));
+    public IList<string> Build(string bicepPath, string usingPath = "", bool noRestore = false) => joinableTaskFactory.Run(() => BuildAsync(bicepPath, usingPath, noRestore));
 
-    public async Task<IList<string>> BuildAsync(string bicepPath, bool noRestore = false)
+    public async Task<IList<string>> BuildAsync(string bicepPath, string usingPath = "", bool noRestore = false)
     {
         var inputPath = PathHelper.ResolvePath(bicepPath);
         var features = featureProviderFactory.GetFeatureProvider(PathHelper.FilePathToFileUrl(inputPath));
@@ -41,7 +42,7 @@ public partial class BicepWrapper
         EmitResult emitresult = fileKind switch
         {
             BicepSourceFileKind.BicepFile => new TemplateEmitter(compilation.GetEntrypointSemanticModel()).Emit(stream),
-            BicepSourceFileKind.ParamsFile => new ParametersEmitter(compilation.GetEntrypointSemanticModel()).Emit(stream),
+            BicepSourceFileKind.ParamsFile => EmitParamsFile(compilation, usingPath, stream),
             _ => throw new NotImplementedException($"Unexpected file kind '{fileKind}'"),
         };
 
@@ -56,5 +57,23 @@ public partial class BicepWrapper
         template.Add(result);
 
         return template;
+    }
+
+    private static EmitResult EmitParamsFile(Compilation compilation, string usingPath, Stream stream)
+    {
+        var bicepPath = PathHelper.ResolvePath(usingPath);
+        var paramsSemanticModel = compilation.GetEntrypointSemanticModel();
+        if (usingPath != "" && paramsSemanticModel.Root.TryGetBicepFileSemanticModelViaUsing(out var bicepSemanticModel, out _))
+        {
+            var bicepFileUsingPathUri = bicepSemanticModel.Root.FileUri;
+
+            if (bicepPath is { } && !bicepFileUsingPathUri.Equals(PathHelper.FilePathToFileUrl(bicepPath)))
+            {
+                throw new InvalidOperationException($"Bicep file {bicepPath} provided with templatePath option doesn't match the Bicep file {bicepSemanticModel.Root.Name} referenced by the using declaration in the parameters file");
+            }
+
+        }
+        var emitter = new ParametersEmitter(paramsSemanticModel);
+        return emitter.Emit(stream);
     }
 }

--- a/BicepNet.Core/BicepWrapper.Build.cs
+++ b/BicepNet.Core/BicepWrapper.Build.cs
@@ -33,7 +33,7 @@ public partial class BicepWrapper
         var compilation = await compilationService.CompileAsync(inputPath, noRestore);
         if (diagnosticLogger is not null && diagnosticLogger.ErrorCount > 0)
         {
-            throw new InvalidOperationException($"Failed to compile template: {inputPath}");
+            throw new InvalidOperationException($"Failed to compile file: {inputPath}");
         }
 
         var stream = new MemoryStream();

--- a/BicepNet.Core/BicepWrapper.Publish.cs
+++ b/BicepNet.Core/BicepWrapper.Publish.cs
@@ -40,7 +40,6 @@ public partial class BicepWrapper
 
             stream.Position = 0;
             await PublishModuleAsync(moduleReference, stream);
-            return;
         }
     }
 

--- a/BicepNet.PS/Commands/BuildBicepNetParamFileCommand.cs
+++ b/BicepNet.PS/Commands/BuildBicepNetParamFileCommand.cs
@@ -2,19 +2,22 @@ using System.Management.Automation;
 
 namespace BicepNet.PS.Commands;
 
-[Cmdlet(VerbsLifecycle.Build, "BicepNetFile")]
-public class BuildBicepNetFileCommand : BicepNetBaseCommand
+[Cmdlet(VerbsLifecycle.Build, "BicepNetParamFile")]
+public class BuildBicepNetParamFileCommand : BicepNetBaseCommand
 {
     [Parameter(Mandatory = true, ValueFromPipeline = true)]
     [ValidateNotNullOrEmpty]
     public string Path { get; set; }
+
+    [Parameter(Mandatory = false)]
+    public string TemplatePath { get; set; } = "";
 
     [Parameter()]
     public SwitchParameter NoRestore { get; set; }
 
     protected override void ProcessRecord()
     {
-        var result = bicepWrapper.Build(Path, noRestore: NoRestore.IsPresent);
+        var result = bicepWrapper.Build(Path, TemplatePath, NoRestore.IsPresent);
         WriteObject(result);
     }
 }

--- a/BicepNet.PS/Commands/BuildBicepNetParamFileCommand.cs
+++ b/BicepNet.PS/Commands/BuildBicepNetParamFileCommand.cs
@@ -10,6 +10,7 @@ public class BuildBicepNetParamFileCommand : BicepNetBaseCommand
     public string Path { get; set; }
 
     [Parameter(Mandatory = false)]
+    [ValidateNotNullOrEmpty]
     public string TemplatePath { get; set; } = "";
 
     [Parameter()]

--- a/BicepNet.PS/Manifest/BicepNet.PS.psd1
+++ b/BicepNet.PS/Manifest/BicepNet.PS.psd1
@@ -40,6 +40,7 @@ BicepNet is developed for the Bicep PowerShell module but could be used for any 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport      = @(
         'Build-BicepNetFile'
+        'Build-BicepNetParamFile'
         'Clear-BicepNetCredential'
         'Convert-BicepNetResourceToBicep'
         'ConvertTo-BicepNetFile'


### PR DESCRIPTION
Slightly rewrote BicepWrapper.Build to support optional validation of using statement in bicepparam file.

This should be consistent with the CLI argument on `bicep build-params main.bicepparam --bicep-file main.bicep`