### PR TITLE
Prepare for release v2.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,13 +91,13 @@ jobs:
 
     - name: Publish Release
       shell: pwsh
-      run: Write-Host 'Publishing' #Import-Module ./output/RequiredModules/PowerShellForGitHub/0.16.1/PowerShellForGitHub.psd1 ; ./build.ps1 -tasks publish
+      run: Import-Module ./output/RequiredModules/PowerShellForGitHub/0.16.1/PowerShellForGitHub.psd1 ; ./build.ps1 -tasks publish
       env:
         GitHubToken: ${{ secrets.GITHUB_TOKEN }}
         GalleryApiToken: ${{ secrets.BICEPNET_PSGALLERY_KEY }}
 
-    # - name: Send Changelog PR
-    #   shell: pwsh
-    #   run: Get-Module -Name PowerShellForGitHub -ListAvailable ;./build.ps1  -tasks Create_ChangeLog_GitHub_PR
-    #   env:
-    #     GitHubToken: ${{ secrets.GITHUB_TOKEN }}
+    - name: Send Changelog PR
+      shell: pwsh
+      run: Get-Module -Name PowerShellForGitHub -ListAvailable ;./build.ps1  -tasks Create_ChangeLog_GitHub_PR
+      env:
+        GitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/BicepNet.PS/BicepNet.PS.psd1
+++ b/BicepNet.PS/BicepNet.PS.psd1
@@ -4,7 +4,7 @@
     NestedModules        = 'BicepNet.PS/BicepNet.PS.dll'
 
     # Version number of this module.
-    ModuleVersion        = '2.1.0'
+    ModuleVersion        = '2.2.0'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Core')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,23 +8,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for bicep v0.20.4
-
-### Changed
-
-- For changes in existing functionality.
-
-### Deprecated
-
-- For soon-to-be removed features.
-
-### Removed
-
-- For now removed features.
-
-### Fixed
-
-- For any bug fix.
-
-### Security
-
-- In case of vulnerabilities.


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description
Prep for release v2.2.0

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Markdown help added/updated.
- [ ] Unit tests added/updated.
