### PR TITLE
Change ProjectPath parameter for Build task to avoid future potential duplicate Pester tests

### DIFF
--- a/.build/tasks/BicepNet.build.ps1
+++ b/.build/tasks/BicepNet.build.ps1
@@ -1,6 +1,6 @@
 param (
     [string[]]
-    $Paths = @('BicepNet.Core', 'BicepNet.PS'),
+    $Path = @('BicepNet.Core', 'BicepNet.PS'),
 
     [ValidateSet('Debug', 'Release')]
     [string]
@@ -22,23 +22,23 @@ task dotnetBuild {
         dotnet build-server shutdown
     }
 
-    foreach ($path in $Paths) {
-        $outPathFolder = Split-Path -Path (Resolve-Path -Path $path) -Leaf
-        Write-Host $Path
+    foreach ($projPath in $Path) {
+        $outPathFolder = Split-Path -Path (Resolve-Path -Path $projPath) -Leaf
+        Write-Host $projPath
         Write-Host $outPathFolder
         $outPath = "bin/$outPathFolder"
-        if (-not (Test-Path -Path $path)) {
-            throw "Path '$path' does not exist."
+        if (-not (Test-Path -Path $projPath)) {
+            throw "Path '$projPath' does not exist."
         }
 
-        Push-Location -Path $path
+        Push-Location -Path $projPath
 
         # Remove output folder if exists
         if (Test-Path -Path $outPath) {
             Remove-Item -Path $outPath -Recurse -Force
         }
 
-        Write-Host "Building '$path' to '$outPath'" -ForegroundColor 'Magenta'
+        Write-Host "Building '$projPath' to '$outPath'" -ForegroundColor 'Magenta'
         dotnet publish -c $Configuration -o $outPath
 
         # Remove everything we don't need from the build

--- a/.build/tasks/BicepNet.build.ps1
+++ b/.build/tasks/BicepNet.build.ps1
@@ -1,6 +1,6 @@
 param (
     [string[]]
-    $ProjectPath = @('BicepNet.Core', 'BicepNet.PS'),
+    $Paths = @('BicepNet.Core', 'BicepNet.PS'),
 
     [ValidateSet('Debug', 'Release')]
     [string]
@@ -22,7 +22,7 @@ task dotnetBuild {
         dotnet build-server shutdown
     }
 
-    foreach ($path in $ProjectPath) {
+    foreach ($path in $Paths) {
         $outPathFolder = Split-Path -Path (Resolve-Path -Path $path) -Leaf
         Write-Host $Path
         Write-Host $outPathFolder


### PR DESCRIPTION
# Pull Request

<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    TITLE: Please be descriptive not sensationalist.
    Prepend the title with [BREAKING CHANGE] if relevant.
    i.e. [BREAKING CHANGE] Add support for X

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
    Try to keep your PRs atomic: changes grouped in smallest batch affecting a single logical unit.
-->

## Pull Request (PR) description

This PR will look mostly useless considering we don't use Pester in BicepNet, but I found a crazy edge case in https://github.com/PalmEmanuel/AzBobbyTables when implementing Sampler and felt the need to document it somewhere 😅 

If the parameter to this task (likely to any task run after `Build_Module_ModuleBuilder`) is named `$ProjectPath`, it will overwrite whatever value Sampler set up to provide for Pester. Since Pester accepts multiple paths, the result is that it will try to find "$ProjectPath/$[WhateverValueIsConfiguredHere](https://github.com/PSBicep/PSBicep/blob/9e5a0688240aa43fad16c97d6afcc44c3ce457f9/build.yaml#L111)" for all paths. For BicepNet it would try to find tests in both `BicepNet.PS/Tests` and `BicepNet.Core/Tests`, and if you change the line linked above to a relative paths it will result in all tests being found and run twice.

Even if we don't use Pester here, I felt like this was a good place to fix it and explain why.

<!--
    Replace this comment block with a description of your PR to provide context.
    Please be describe the intent and link issue where the problem has been discussed.
    try to link the issue that it fixes by providing the verb and ref: [fix|close #18]

    After the description, please concisely list the changes as per keepachangelog.com
    This **should** duplicate what you've updated in the changelog file.

### Added
- for new features [closes #15]
### Changed
- for changes in existing functionality.
### Deprecated
- for soon-to-be removed features.
### Security
- in case of vulnerabilities.
### Fixed
- for any bug fixes. [fix #52]
### Removed
- for now removed features.
-->

## Task list

<!--
    To aid reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [X] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [ ] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [ ] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Markdown help added/updated.
- [ ] Unit tests added/updated.
