### PR TITLE
Fixes config path to Pester tests

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -95,49 +95,10 @@ BuildWorkflow:
 
 Pester:
   OutputFormat: NUnitXML
-  # Excludes one or more paths from being used to calculate code coverage.
-  ExcludeFromCodeCoverage:
-
-  # If no scripts are defined the default is to use all the tests under the project's
-  # tests folder or source folder (if present). Test script paths can be defined to
-  # only run tests in certain folders, or run specific test files, or can be use to
-  # specify the order tests are run.
-  Script:
-  # - tests/QA/module.tests.ps1
-  # - tests/QA
-  # - tests/Unit
-  # - tests/Integration
-  ExcludeTag:
-  #  - helpQuality
-  #  - FunctionalQuality
-  #  - TestQuality
-  Tag:
-  CodeCoverageThreshold: 0 # Set to 0 to bypass
-  #CodeCoverageOutputFile: JaCoCo_$OsShortName.xml
-  #CodeCoverageOutputFileEncoding: ascii
-  # Use this if code coverage should be merged from several pipeline test jobs.
-  # Any existing keys above should be replaced. See also CodeCoverage below.
-  # CodeCoverageOutputFile is the file that is created for each pipeline test job.
-  #CodeCoverageOutputFile: JaCoCo_Merge.xml
-
-# Use this to merged code coverage from several pipeline test jobs.
-# CodeCoverageFilePattern      - the pattern used to search all pipeline test job artifacts
-#                                after the file specified in CodeCoverageOutputFile.
-# CodeCoverageMergedOutputFile - the file that is created by the merge build task and
-#                                is the file that should be uploaded to code coverage services.
-#CodeCoverage:
-  #CodeCoverageFilePattern: JaCoCo_Merge.xml # the pattern used to search all pipeline test job artifacts
-  #CodeCoverageMergedOutputFile: JaCoCo_coverage.xml # the file that is created for the merged code coverage
-
-# DscTest:
-#   ExcludeTag:
-#     - "Common Tests - New Error-Level Script Analyzer Rules"
-#   Tag:
-#   ExcludeSourceFile:
-#     - output
-#   ExcludeModuleFile:
-#     - Modules/DscResource.Common
-#     - Templates
+  Configuration:
+    Run:
+      Path:
+        - BicepNet.PS/tests
 
 # Import ModuleBuilder tasks from a specific PowerShell module using the build
 # task's alias. Wildcard * can be used to specify all tasks that has a similar


### PR DESCRIPTION
# Pull Request

<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    TITLE: Please be descriptive not sensationalist.
    Prepend the title with [BREAKING CHANGE] if relevant.
    i.e. [BREAKING CHANGE] Add support for X

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
    Try to keep your PRs atomic: changes grouped in smallest batch affecting a single logical unit.
-->

## Pull Request (PR) description

This fixes the current issue where the test process doesn't find the `./BicepNet.PS/tests` folder automatically by specifying it in `build.yaml`.

### Fixed
- Path to Pester tests is now specified.

## Task list

- [X] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [X] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).