### PR TITLE
Add necessary permissions for test results publish step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,9 @@ jobs:
     - build
     - test-linux
     # - test-win
+    permissions:
+      checks: write
+      pull-requests: write
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

This PR adds permissions to the step in the CI workflow which publishes the test results. Currently it seems to fail without it with http error `forbidden`.
