### PR TITLE
Change `master` to `main` in `gitversion` configuration

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -15,27 +15,15 @@ branches:
     tag: useBranchName
     increment: Minor
     regex: f(eature(s)?)?[\/-]
-    source-branches: ['master']
+    source-branches: ['main']
   hotfix:
     tag: fix
     increment: Patch
     regex: (hot)?fix(es)?[\/-]
-    source-branches: ['master']
+    source-branches: ['main']
 
 ignore:
   sha: []
 merge-message-formats: {}
-
-
-# feature:
-#   tag: useBranchName
-#   increment: Minor
-#   regex: f(eature(s)?)?[/-]
-#   source-branches: ['master']
-# hotfix:
-#   tag: fix
-#   increment: Patch
-#   regex: (hot)?fix(es)?[/-]
-#   source-branches: ['master']
 
 tag-prefix: '[vV]'

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-mode: ContinuousDelivery
+mode: Mainline
 next-version: 0.0.1
 major-version-bump-message: '(breaking\schange|breaking|major)\b'
 minor-version-bump-message: '(adds?|features?|minor)\b'


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

Consistency fix for PSBicep in `gitversion` config. Some parts still pointed to `master` instead of `main`. This fix mirrors part of https://github.com/PSBicep/PSBicep/pull/333 for the same reason.